### PR TITLE
MDEXP-307: Removing guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,11 +52,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>30.0-jre</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>2.9.1</version>


### PR DESCRIPTION
We are not using the guava library at all, removing it from the pom.xml