### PR TITLE
MDEXP-326 Fix missing standard number and GPO Item identifiers

### DIFF
--- a/src/main/java/org/folio/processor/translations/TranslationsFunctionHolder.java
+++ b/src/main/java/org/folio/processor/translations/TranslationsFunctionHolder.java
@@ -64,7 +64,7 @@ public enum TranslationsFunctionHolder implements TranslationFunction, Translati
         if (!identifierTypeIds.isEmpty()) {
           String identifierTypeId = identifierTypeIds.get(currentIndex);
           JsonObject identifierType = referenceData.get(IDENTIFIER_TYPES).get(identifierTypeId);
-          if (identifierType != null && identifierType.getString(NAME).equals(translation.getParameter("type"))) {
+          if (identifierType != null && identifierType.getString(NAME).equalsIgnoreCase(translation.getParameter("type"))) {
             return identifierValue;
           }
         }
@@ -81,7 +81,7 @@ public enum TranslationsFunctionHolder implements TranslationFunction, Translati
         if (!contributorNameTypeIds.isEmpty()) {
           String contributorNameTypeId = contributorNameTypeIds.get(currentIndex);
           JsonObject contributorNameType = referenceData.get(CONTRIBUTOR_NAME_TYPES).get(contributorNameTypeId);
-          if (contributorNameType != null && contributorNameType.getString(NAME).equals(translation.getParameter("type"))) {
+          if (contributorNameType != null && contributorNameType.getString(NAME).equalsIgnoreCase(translation.getParameter("type"))) {
             return identifierValue;
           }
         }
@@ -251,7 +251,7 @@ public enum TranslationsFunctionHolder implements TranslationFunction, Translati
         if (relationship != null) {
           String relationshipName = relationship.getString(NAME);
           for (Map.Entry<String, String> parameter : translation.getParameters().entrySet()) {
-            if (relationshipName.equals(parameter.getKey())) {
+            if (relationshipName.equalsIgnoreCase(parameter.getKey())) {
               return parameter.getValue();
             }
           }

--- a/src/test/java/org/folio/holder/TranslationFunctionHolderUnitTest.java
+++ b/src/test/java/org/folio/holder/TranslationFunctionHolderUnitTest.java
@@ -123,6 +123,25 @@ class TranslationFunctionHolderUnitTest {
   }
 
   @Test
+  void SetIdentifier_shouldReturnIdentifierValue_forSystemControlNumber() throws ParseException {
+    // given
+    String value = "value";
+    TranslationFunction translationFunction = TranslationsFunctionHolder.SET_IDENTIFIER;
+
+    Translation translation = new Translation();
+    translation.setParameters(Collections.singletonMap("type", "System control number"));
+
+    Metadata metadata = new Metadata();
+    metadata.addData("identifierTypeId",
+      new Metadata.Entry("$.identifiers[*].identifierTypeId",
+        singletonList("7e591197-f335-4afb-bc6d-a6d76ca3bace")));
+    // when
+    String result = translationFunction.apply(value, 0, translation, referenceData, metadata);
+    // then
+    Assert.assertEquals(value, result);
+  }
+
+  @Test
   void SetIdentifier_shouldReturnEmptyString_whenMetadataIsEmpty() throws ParseException {
     // given
     String value = "value";

--- a/src/test/resources/mockData/inventory/get_identifier_types_response.json
+++ b/src/test/resources/mockData/inventory/get_identifier_types_response.json
@@ -22,7 +22,7 @@
     },
     {
       "id": "7e591197-f335-4afb-bc6d-a6d76ca3bace",
-      "name": "System control number",
+      "name": "System Control Number",
       "source": "folio"
     },
     {


### PR DESCRIPTION
**PURPOSE:**
https://issues.folio.org/browse/MDEXP-326

**APPROACH:**
The name of reference data could be in the upper or lower case, so changed equals to equalsIgnoreCase as proposed in the ticket.