### PR TITLE
MDEXP-328: Bugfix release 1.0.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,12 @@
 ## 10/14/2020 v1.0.0 - Released
 
- * Initial module release with common functionalities for generating records in MARC format 
+ * Initial module release with common functionalities for generating records in MARC format
  * Has capabilities to read records in json format, parse and apply translation functions
+
+ ## 06/11/2020 v1.0.1 Bug Fixes
+
+* [MDEXP-307](https://issues.folio.org/browse/MDEXP-307) - Fix security dependency issue
+* [MDEXP-308](https://issues.folio.org/browse/MDEXP-308) - Subfield $3 is missing for the MARC tags with item data
+* [MDEXP-326](https://issues.folio.org/browse/MDEXP-326) - Missing Standard Number and GPO Item identifiers
+
+

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,17 @@
-## 10/14/2020 v1.0.0 - Released
+ ## 06/11/2020 v1.0.1 - Released
+ This bugfix release includes fixes for the mapping process to fail due to a change in date formats in the metadata,
+ it also includes  changes to support subfield 3 that contain holding hrid for record with item type in MARC file.
+ A part from that, it contains a fix of missing standard number and GPO item identified if identifier type in inventory-storage
+ is present in uppercase or lowercase format and removes the unused guava library.
 
- * Initial module release with common functionalities for generating records in MARC format
- * Has capabilities to read records in json format, parse and apply translation functions
+[Full Changelog](https://github.com/folio-org/generate-marc-utils/compare/v1.0.0...v1.0.1)
 
- ## 06/11/2020 v1.0.1 Bug Fixes
-
+### Bug Fixes
 * [MDEXP-307](https://issues.folio.org/browse/MDEXP-307) - Fix security dependency issue
 * [MDEXP-308](https://issues.folio.org/browse/MDEXP-308) - Subfield $3 is missing for the MARC tags with item data
 * [MDEXP-326](https://issues.folio.org/browse/MDEXP-326) - Missing Standard Number and GPO Item identifiers
 
+## 10/14/2020 v1.0.0 - Released
 
+ * Initial module release with common functionalities for generating records in MARC format
+ * Has capabilities to read records in json format, parse and apply translation functions

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </repositories>
 
   <properties>
-    <raml-module-builder.version>31.1.2</raml-module-builder.version>
+    <raml-module-builder.version>31.1.5</raml-module-builder.version>
     <marc4j.version>2.9.1</marc4j.version>
     <junit.version>5.4.2</junit.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>generate-marc-utils</artifactId>
-  <version>1.0.1</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>generate-marc-utils</name>
   <organization>
@@ -101,7 +101,7 @@
     <url>https://github.com/folio-org/generate-marc-utils</url>
     <connection>scm:git:git@github.com:folio-org/generate-marc-utils.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/generate-marc-utils.git</developerConnection>
-    <tag>v1.0.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>generate-marc-utils</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.0.1</version>
   <packaging>jar</packaging>
   <name>generate-marc-utils</name>
   <organization>
@@ -101,7 +101,7 @@
     <url>https://github.com/folio-org/generate-marc-utils</url>
     <connection>scm:git:git@github.com:folio-org/generate-marc-utils.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/generate-marc-utils.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v1.0.1</tag>
   </scm>
 
   <build>


### PR DESCRIPTION
https://issues.folio.org/browse/MDEXP-328

**PURPOSE:**
This bugfix release includes fixes for the mapping process to fail due to a change in date formats in the metadata,
also it includes changes to support subfield 3 that contain holding hrid for record with item type in MARC file.
A part from that, it contains a fix of missing standard number and GPO item identified if identifier type in inventory-storage
is present in uppercase or lowercase format and removing of unused guava library.