### PR TITLE
MDEXP-351 Fix empty record present in marc file

### DIFF
--- a/src/main/java/org/folio/writer/impl/JsonRecordWriter.java
+++ b/src/main/java/org/folio/writer/impl/JsonRecordWriter.java
@@ -1,5 +1,7 @@
 package org.folio.writer.impl;
 
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.writer.RecordWriter;
 import org.marc4j.MarcJsonWriter;
 import org.marc4j.MarcWriter;
@@ -15,8 +17,13 @@ public class JsonRecordWriter extends MarcRecordWriter {
   public String getResult() {
     OutputStream outputStream = new ByteArrayOutputStream();
     MarcWriter writer = new MarcJsonWriter(outputStream);
-    writer.write(record);
-    writer.close();
-    return outputStream.toString();
+    if (CollectionUtils.isNotEmpty(getFields())) {
+      writer.write(record);
+      writer.close();
+      return outputStream.toString();
+    } else {
+      writer.close();
+      return StringUtils.EMPTY;
+    }
   }
 }

--- a/src/main/java/org/folio/writer/impl/MarcRecordWriter.java
+++ b/src/main/java/org/folio/writer/impl/MarcRecordWriter.java
@@ -1,5 +1,7 @@
 package org.folio.writer.impl;
 
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.processor.translations.Translation;
 import org.folio.writer.RecordWriter;
 import org.folio.writer.fields.RecordControlField;
@@ -59,9 +61,14 @@ public class MarcRecordWriter extends AbstractRecordWriter {
   public String getResult() {
     OutputStream outputStream = new ByteArrayOutputStream();
     MarcWriter writer = new MarcStreamWriter(outputStream, encoding);
-    writer.write(record);
-    writer.close();
-    return outputStream.toString();
+    if (CollectionUtils.isNotEmpty(getFields())) {
+      writer.write(record);
+      writer.close();
+      return outputStream.toString();
+    } else {
+      writer.close();
+      return StringUtils.EMPTY;
+    }
   }
 
   @Override

--- a/src/main/java/org/folio/writer/impl/XmlRecordWriter.java
+++ b/src/main/java/org/folio/writer/impl/XmlRecordWriter.java
@@ -1,5 +1,7 @@
 package org.folio.writer.impl;
 
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.writer.RecordWriter;
 import org.marc4j.MarcWriter;
 import org.marc4j.MarcXmlWriter;
@@ -15,8 +17,13 @@ public class XmlRecordWriter extends MarcRecordWriter {
   public String getResult() {
     OutputStream outputStream = new ByteArrayOutputStream();
     MarcWriter writer = new MarcXmlWriter(outputStream, encoding);
-    writer.write(record);
-    writer.close();
-    return outputStream.toString();
+    if (CollectionUtils.isNotEmpty(getFields())) {
+      writer.write(record);
+      writer.close();
+      return outputStream.toString();
+    } else {
+      writer.close();
+      return StringUtils.EMPTY;
+    }
   }
 }

--- a/src/test/java/org/folio/processor/RuleProcessorTest.java
+++ b/src/test/java/org/folio/processor/RuleProcessorTest.java
@@ -2,6 +2,7 @@ package org.folio.processor;
 
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.processor.referencedata.ReferenceData;
 import org.folio.processor.rule.DataSource;
 import org.folio.processor.rule.Metadata;
@@ -131,6 +132,42 @@ class RuleProcessorTest {
     ControlField actualControlField = (ControlField)actualVariableFields.get(0);
     assertEquals("001", actualControlField.getTag());
     assertEquals("4bbec474-ba4d-4404-990f-afe2fc86dd3d", actualControlField.getData());
+  }
+
+  @Test
+  void shouldReturnEmpty_ForEmptyEntity_MarcRecord() {
+    // given
+    RuleProcessor ruleProcessor = new RuleProcessor(translationHolder);
+    EntityReader reader = new JPathSyntaxEntityReader(new JsonObject());
+    RecordWriter writer = new MarcRecordWriter();
+    // when
+    String actualJsonRecord = ruleProcessor.process(reader, writer, referenceData, rules, null);
+    // then
+    assertEquals(StringUtils.EMPTY, actualJsonRecord);
+  }
+
+  @Test
+  void shouldReturnEmpty_ForEmptyEntity_JsonRecord() {
+    // given
+    RuleProcessor ruleProcessor = new RuleProcessor(translationHolder);
+    EntityReader reader = new JPathSyntaxEntityReader(new JsonObject());
+    RecordWriter writer = new JsonRecordWriter();
+    // when
+    String actualJsonRecord = ruleProcessor.process(reader, writer, referenceData, rules, null);
+    // then
+    assertEquals(StringUtils.EMPTY, actualJsonRecord);
+  }
+
+  @Test
+  void shouldReturnEmpty_ForEmptyEntity_XmlRecord() {
+    // given
+    RuleProcessor ruleProcessor = new RuleProcessor(translationHolder);
+    EntityReader reader = new JPathSyntaxEntityReader(new JsonObject());
+    RecordWriter writer = new XmlRecordWriter();
+    // when
+    String actualJsonRecord = ruleProcessor.process(reader, writer, referenceData, rules, null);
+    // then
+    assertEquals(StringUtils.EMPTY, actualJsonRecord);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
**PURPOSE**

https://issues.folio.org/browse/MDEXP-351

**APPROACH:**

If an instance doesn`t have holding, the record will look like the broken record: only the default leader is present. By default, the marc4j library creates a record with such a leader: 00026nam a2200025 a 4500. Added an additional check, to not include records without fields in the marc file.