### PR TITLE
MDEXP-345 - renamed field

### DIFF
--- a/src/main/java/org/folio/processor/rule/Rule.java
+++ b/src/main/java/org/folio/processor/rule/Rule.java
@@ -14,7 +14,8 @@ public class Rule {
   private List<DataSource> dataSources;
   private Metadata metadata;
   private String id;
-  private boolean hasSameTagInItems;
+  /* The flag means that this rule is generated from TransformationField with RecordType equals ITEM */
+  private boolean isItemTypeRule;
 
   public String getField() {
     return field;
@@ -56,12 +57,12 @@ public class Rule {
     this.metadata = metadata;
   }
 
-  public boolean isHasSameTagInItems() {
-    return hasSameTagInItems;
+  public boolean isItemTypeRule() {
+    return isItemTypeRule;
   }
 
-  public void setHasSameTagInItems(boolean hasSameTagInItems) {
-    this.hasSameTagInItems = hasSameTagInItems;
+  public void setItemTypeRule(boolean isItemTypeRule) {
+    this.isItemTypeRule = isItemTypeRule;
   }
 
   public Rule copy() {
@@ -73,7 +74,7 @@ public class Rule {
     List<DataSource> clonedDataSources = new ArrayList<>();
     this.dataSources.forEach(originDataSource -> clonedDataSources.add(originDataSource.copy()));
     rule.setDataSources(clonedDataSources);
-    rule.setHasSameTagInItems(hasSameTagInItems);
+    rule.setItemTypeRule(isItemTypeRule);
     return rule;
   }
 

--- a/src/test/java/org/folio/processor/RuleProcessorTest.java
+++ b/src/test/java/org/folio/processor/RuleProcessorTest.java
@@ -240,6 +240,7 @@ class RuleProcessorTest {
     givenRule.setDescription("test description");
     givenRule.setField("test field");
     givenRule.setMetadata(Collections.singletonMap("test key", "test value"));
+    givenRule.setItemTypeRule(true);
     DataSource givenDataSource = new DataSource();
     givenDataSource.setTranslation(new Translation());
     givenDataSource.setIndicator("1");
@@ -252,6 +253,7 @@ class RuleProcessorTest {
     assertEquals(givenRule.getDescription(), copiedRule.getDescription());
     assertEquals(givenRule.getField(), copiedRule.getField());
     assertEquals(givenRule.getMetadata(), copiedRule.getMetadata());
+    assertEquals(givenRule.isItemTypeRule(), copiedRule.isItemTypeRule());
     DataSource copiedDataSource = copiedRule.getDataSources().get(0);
     assertEquals(givenDataSource.getFrom(), copiedDataSource.getFrom());
     assertEquals(givenDataSource.getIndicator(), copiedDataSource.getIndicator());


### PR DESCRIPTION
*Overview*
https://issues.folio.org/browse/MDEXP-345
Linked PR https://github.com/folio-org/mod-data-export/pull/228

*Approach*
Renamed Rule field 'hasSameTagInItems' to 'isItemTypeRule'.
'isItemTypeRule' means that this rule is generated from TransformationField with RecordType equals ITEM.
These changes are needed for the linked PR to MDEXP