### PR TITLE
MDEXP-364 Add null/empty metadata check for some translation functions

### DIFF
--- a/src/main/java/org/folio/processor/translations/TranslationsFunctionHolder.java
+++ b/src/main/java/org/folio/processor/translations/TranslationsFunctionHolder.java
@@ -54,7 +54,7 @@ public enum TranslationsFunctionHolder implements TranslationFunction, Translati
       Object metadataIdentifierTypeIds = metadata.getData().get(IDENTIFIER_TYPE_METADATA).getData();
       if (metadataIdentifierTypeIds != null) {
         List<Map<String, String>> identifierTypes = (List<Map<String, String>>) metadataIdentifierTypeIds;
-        if (identifierTypes.size() > currentIndex) {
+        if (isNotEmpty(identifierTypes) && identifierTypes.size() > currentIndex) {
           Map<String, String> currentIdentifierType = identifierTypes.get(currentIndex);
           JSONObject identifierType = convertToJson(currentIdentifierType.get(IDENTIFIER_TYPE_ID_PARAM), referenceData, IDENTIFIER_TYPES);
           if (!identifierType.isEmpty() && identifierType.getAsString(NAME).equalsIgnoreCase(translation.getParameter("type"))) {
@@ -71,7 +71,7 @@ public enum TranslationsFunctionHolder implements TranslationFunction, Translati
       Object metadataIdentifierTypeIds = metadata.getData().get(IDENTIFIER_TYPE_METADATA).getData();
       if (metadataIdentifierTypeIds != null) {
         List<Map<String, String>> identifierTypes = (List<Map<String, String>>) metadataIdentifierTypeIds;
-        if (identifierTypes.size() > currentIndex) {
+        if (isNotEmpty(identifierTypes) && identifierTypes.size() > currentIndex) {
           Map<String, String> currentIdentifierType = identifierTypes.get(currentIndex);
           JSONObject currentIdentifierTypeReferenceData = convertToJson(currentIdentifierType.get(IDENTIFIER_TYPE_ID_PARAM), referenceData, IDENTIFIER_TYPES);
           List<String> relatedIdentifierTypes = Splitter.on(",").splitToList(translation.getParameter(RELATED_IDENTIFIER_TYPES_PARAM));
@@ -101,7 +101,7 @@ public enum TranslationsFunctionHolder implements TranslationFunction, Translati
       Object metadataContributorNameTypeIds = metadata.getData().get("contributorNameTypeId").getData();
       if (metadataContributorNameTypeIds != null) {
         List<String> contributorNameTypeIds = (List<String>) metadataContributorNameTypeIds;
-        if (contributorNameTypeIds.size() > currentIndex) {
+        if (isNotEmpty(contributorNameTypeIds) && contributorNameTypeIds.size() > currentIndex) {
           String contributorNameTypeId = contributorNameTypeIds.get(currentIndex);
           JSONObject contributorNameType = convertToJson(contributorNameTypeId, referenceData, CONTRIBUTOR_NAME_TYPES);
           if (!contributorNameType.isEmpty() && contributorNameType.getAsString(NAME).equalsIgnoreCase(translation.getParameter("type"))) {

--- a/src/test/java/org/folio/holder/TranslationFunctionHolderUnitTest.java
+++ b/src/test/java/org/folio/holder/TranslationFunctionHolderUnitTest.java
@@ -162,6 +162,24 @@ class TranslationFunctionHolderUnitTest {
   }
 
   @Test
+  void SetIdentifier_shouldReturnEmptyString_whenMetadataIsNull() throws ParseException {
+    // given
+    String value = "value";
+    TranslationFunction translationFunction = TranslationsFunctionHolder.SET_IDENTIFIER;
+
+    Translation translation = new Translation();
+    translation.setParameters(Collections.singletonMap("type", "LCCN"));
+
+    Metadata metadata = new Metadata();
+    metadata.addData("identifierType", new Metadata.Entry("$.identifiers[*]", null));
+    // when
+    String result = translationFunction.apply(value, 0, translation, referenceData, metadata);
+    // then
+    Assert.assertEquals(EMPTY, result);
+  }
+
+
+  @Test
   void SetRelatedIdentifier_shouldReturnEmptyValue_whenRelatedIdentifierDoesNotMatchCurrentIdentifierValue() throws ParseException {
     // given
     String value = "value";
@@ -176,6 +194,25 @@ class TranslationFunctionHolderUnitTest {
     metadata.addData("identifierType",
       new Metadata.Entry("$.identifiers[*]",
         asList(ImmutableMap.of("value", "invalid isbn value", "identifierTypeId", "47c7bf8e-d2a3-4b3f-84b8-79944031a55a"))));
+    // when
+    String result = translationFunction.apply(value, 0, translation, referenceData, metadata);
+    // then
+    Assert.assertEquals(EMPTY, result);
+  }
+
+  @Test
+  void SetRelatedIdentifier_shouldReturnEmptyValue_whenIdentifierTypeNull() throws ParseException {
+    // given
+    String value = "value";
+    TranslationFunction translationFunction = TranslationsFunctionHolder.SET_RELATED_IDENTIFIER;
+
+    Translation translation = new Translation();
+    translation.setParameters(ImmutableMap.of(
+      "relatedIdentifierTypes", "ISBN",
+      "type", "Invalid ISBN"));
+
+    Metadata metadata = new Metadata();
+    metadata.addData("identifierType", new Metadata.Entry("$.identifiers[*]", null));
     // when
     String result = translationFunction.apply(value, 0, translation, referenceData, metadata);
     // then
@@ -547,6 +584,23 @@ class TranslationFunctionHolderUnitTest {
 
     Metadata metadata = new Metadata();
     metadata.addData("contributorNameTypeId", new Metadata.Entry("$.instance.contributors[?(@.primary && @.primary == true)].contributorNameTypeId", Collections.emptyList()));
+    // when
+    String result = translationFunction.apply(value, 0, translation, referenceData, metadata);
+    // then
+    Assert.assertEquals(EMPTY, result);
+  }
+
+  @Test
+  void setContributor_shouldReturnEmptyString_whenMetadataIsNull() throws ParseException {
+    // given
+    String value = "value";
+    TranslationFunction translationFunction = TranslationsFunctionHolder.SET_CONTRIBUTOR;
+
+    Translation translation = new Translation();
+    translation.setParameters(Collections.singletonMap("type", "Personal name"));
+
+    Metadata metadata = new Metadata();
+    metadata.addData("contributorNameTypeId", new Metadata.Entry("$.instance.contributors[?(@.primary && @.primary == true)].contributorNameTypeId", null));
     // when
     String result = translationFunction.apply(value, 0, translation, referenceData, metadata);
     // then


### PR DESCRIPTION
Add check for null metadata in Set_Identifiers, Set_Related_Identifiers and Set_Contibutors to prevent NullPointeException