### PR TITLE
Iris Bugfix release 1.1.1 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+## 04/02/2021 v1.1.1 - Released
+This bugfix release includes fix for inconsistent results when holdings and items data incorrectly appended to the srs record
+in MARC file.
+
+[Full Changelog](https://github.com/folio-org/generate-marc-utils/compare/v1.1.0...v1.1.1)
+
+### Bug Fixes
+* [MDEXP-385](https://issues.folio.org/browse/MDEXP-385) - Holdings and items data incorrectly appended to the srs record
+
 ## 03/10/2021 v1.1.0 - Released
  Major version release which includes below features :
  * Improve error handling to detect which record exactly leads to the exception during the export to the error logs

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>generate-marc-utils</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.1.1</version>
   <packaging>jar</packaging>
   <name>generate-marc-utils</name>
   <organization>
@@ -131,7 +131,7 @@
     <url>https://github.com/folio-org/generate-marc-utils</url>
     <connection>scm:git:git@github.com:folio-org/generate-marc-utils.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/generate-marc-utils.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v1.1.1</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>generate-marc-utils</artifactId>
-  <version>1.1.1</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>generate-marc-utils</name>
   <organization>
@@ -131,7 +131,7 @@
     <url>https://github.com/folio-org/generate-marc-utils</url>
     <connection>scm:git:git@github.com:folio-org/generate-marc-utils.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/generate-marc-utils.git</developerConnection>
-    <tag>v1.1.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <build>


### PR DESCRIPTION
https://issues.folio.org/browse/MDEXP-385

PURPOSE:
This bugfix release includes fixing for inconsistent results when holdings and items data incorrectly appended to the srs record
in MARC file.