### PR TITLE
GMU-7 - Missing holdings statement causes permanent location to be omitted in the export

### DIFF
--- a/src/main/java/org/folio/reader/JPathSyntaxEntityReader.java
+++ b/src/main/java/org/folio/reader/JPathSyntaxEntityReader.java
@@ -97,13 +97,21 @@ public class JPathSyntaxEntityReader extends AbstractEntityReader {
   protected RuleValue readCompositeValue(Rule rule) {
     populateMetadata(rule);
     List<SimpleEntry<DataSource, List<ValueWrapper>>> matrix = readMatrix(rule);
-    if (CollectionUtils.isEmpty(matrix.get(0).getValue())) {
+    if (isMatrixEmpty(matrix)) {
       return MissingValue.getInstance();
     } else {
       CompositeValue compositeValue = buildCompositeValue(matrix);
       applyReadDependingOnDataSourceFlag(compositeValue);
       return compositeValue;
     }
+  }
+
+  /**
+   * Checks whether there is at least one non-empty entry in the matrix and returns false
+   * if found, otherwise true.
+   */
+  private boolean isMatrixEmpty(List<SimpleEntry<DataSource, List<ValueWrapper>>> matrix) {
+    return !matrix.stream().filter(entry -> !entry.getValue().isEmpty()).findFirst().isPresent();
   }
 
   /**


### PR DESCRIPTION
[GMU-7](https://issues.folio.org/browse/GMU-7) - Missing holdings statement causes permanent location to be omitted in the export

## Purpose
Modify logic of processing for composite Rules

## Approach
Initially, when the first entry of composite Rule was empty (for example, holdings statements), then the rule processor skipped all the other entries, even they were not empty (for example, permanent location). To fix this logic, it needs to check all entries in the Rule and if at least one of them has a value, continue processing.

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [x] There are no major code smells or security issues
 - Does this introduce breaking changes?
   - [ ] Were any API paths or methods changed, added or removed?
   - [ ] Were there any schema changes?
   - [ ] Did any of the interface versions change?
   - [ ] Were permissions changed, added, or removed?
   - [ ] Are there new interface dependencies?
   - [x] There are no breaking changes in this PR.

 If there are breaking changes, please **STOP** and consider the following:

 - What other modules will these changes impact?
 - Do JIRAs exist to update the impacted modules?
   - [ ] If not, please create them
   - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
   - [ ] Do they have all they appropriate links to blocked/related issues?
 - Are the JIRAs under active development?
   - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
 - Do PRs exist for these changes?
   - [ ] If so, have they been approved?

 Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

 While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
