### PR TITLE
MDEXP-480: Only one mapping is executed during the export

### DIFF
--- a/src/main/java/org/folio/processor/rule/Rule.java
+++ b/src/main/java/org/folio/processor/rule/Rule.java
@@ -10,6 +10,7 @@ import java.util.Map;
  */
 public class Rule {
   private String field;
+  private String indicators;
   private String description;
   private List<DataSource> dataSources;
   private Metadata metadata;
@@ -23,6 +24,14 @@ public class Rule {
 
   public void setField(String field) {
     this.field = field;
+  }
+
+  public String getIndicators() {
+    return indicators;
+  }
+
+  public void setIndicators(String indicators) {
+    this.indicators = indicators;
   }
 
   public String getDescription() {

--- a/src/test/resources/processor/test_rules.json
+++ b/src/test/resources/processor/test_rules.json
@@ -68,6 +68,7 @@
   },
   {
     "field": "013",
+    "indicators": "11",
     "description": "Test field 013, reading simple string value, writing data field with not empty indicators",
     "dataSources": [
       {


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MDEXP-480

### PURPOSE

Add field to track the uniqueness of the Rule not only by field id but by including the field indicators as well.

Change is required for data-export bug fix logic.