### PR TITLE
GMU-24: Missing data in one subfield excludes whole field from export with the custom mapping profile

### DIFF
--- a/src/main/java/org/folio/processor/rule/DataSource.java
+++ b/src/main/java/org/folio/processor/rule/DataSource.java
@@ -10,7 +10,6 @@ public class DataSource {
   private String subfield;
   private String indicator;
   private Translation translation;
-  private Integer readDependingOnDataSource;
 
   public String getFrom() {
     return from;
@@ -42,14 +41,6 @@ public class DataSource {
 
   public void setTranslation(Translation translation) {
     this.translation = translation;
-  }
-
-  public Integer getReadDependingOnDataSource() {
-    return readDependingOnDataSource;
-  }
-
-  public void setReadDependingOnDataSource(Integer readDependingOnDataSource) {
-    this.readDependingOnDataSource = readDependingOnDataSource;
   }
 
   public DataSource copy() {

--- a/src/test/java/org/folio/processor/RuleProcessorTest.java
+++ b/src/test/java/org/folio/processor/RuleProcessorTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.runner.RunWith;
 import org.marc4j.marc.ControlField;
+import org.marc4j.marc.DataField;
 import org.marc4j.marc.VariableField;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -356,4 +357,22 @@ class RuleProcessorTest {
     // then
     assertNotEquals(StringUtils.EMPTY, marcRecord);
   }
+
+  @Test
+  void shouldNotOmitCompositeFieldWithHoldingHrId_whenOneOfItemFieldsIsNullAndGoesFirstInDataSourceList() {
+    // given
+    entity = readFileContentFromResources("processor/entity_with_item_empty_field.json");
+    RuleProcessor ruleProcessor = new RuleProcessor(translationHolder);
+    EntityReader reader = new JPathSyntaxEntityReader(entity);
+    RecordWriter writer = new XmlRecordWriter();
+    // when
+    List<VariableField> actualVariableFields = ruleProcessor.processFields(reader, writer, referenceData, rules, null);
+    // then
+    DataField dataField = (DataField) actualVariableFields.get(3);
+    assertEquals("020", dataField.getTag());
+    assertEquals(2, dataField.getSubfields().size());
+    assertEquals("$zfcd64ce1-6995-48f0-840e-89ffa2288371", dataField.getSubfields().get(0).toString());
+    assertEquals("$3ho00000000001", dataField.getSubfields().get(1).toString());
+  }
+
 }

--- a/src/test/resources/processor/entity_with_item_empty_field.json
+++ b/src/test/resources/processor/entity_with_item_empty_field.json
@@ -1,0 +1,74 @@
+{
+  "holdings": [
+    {
+      "id": "0a0369fc-0383-47a5-a532-a62e8e3c07b7",
+      "_version": 1,
+      "hrid": "ho00000000001",
+      "formerIds": [],
+      "instanceId": "14f69234-480e-4e93-a90f-66894dec0f43",
+      "permanentLocationId": "53cf956f-c1df-410b-8bea-27f712cca7c0",
+      "temporaryLocationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+      "effectiveLocationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+      "electronicAccess": [],
+      "administrativeNotes": [],
+      "notes": [],
+      "holdingsStatements": [
+        {
+          "statement": "Holdings statement\n",
+          "note": "Holdings statement public note\n",
+          "staffNote": "Holdings statement staff note\n"
+        }
+      ],
+      "holdingsStatementsForIndexes": [],
+      "holdingsStatementsForSupplements": [],
+      "statisticalCodeIds": [],
+      "holdingsItems": [],
+      "bareHoldingsItems": [],
+      "metadata": {
+        "createdDate": "2021-12-29T10:08:02.908+00:00",
+        "createdByUserId": "713b5b3b-2bb1-53a5-ac62-238bbd2696bb",
+        "updatedDate": "2021-12-29T10:08:02.908+00:00",
+        "updatedByUserId": "713b5b3b-2bb1-53a5-ac62-238bbd2696bb"
+      },
+      "sourceId": "f32d531e-df79-46b3-8932-cdd35f7a2264",
+      "items": [
+        {
+          "id": "19370bc4-aa7b-4e4c-9613-f9f1a591eff1",
+          "_version": 4,
+          "hrid": "it00000000001",
+          "holdingsRecordId": "0a0369fc-0383-47a5-a532-a62e8e3c07b7",
+          "formerIds": [],
+          "accessionNumber": "234234234",
+          "barcode": "123123123",
+          "effectiveCallNumberComponents": {},
+          "enumeration": "Enumeration",
+          "chronology": "Chronology",
+          "yearCaption": [],
+          "itemIdentifier": "345345345",
+          "administrativeNotes": [],
+          "notes": [],
+          "circulationNotes": [],
+          "status": {
+            "name": "Available",
+            "date": "2021-12-29T10:08:33.423+00:00"
+          },
+          "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+          "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
+          "effectiveLocationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+          "electronicAccess": [],
+          "statisticalCodeIds": [],
+          "tags": {
+            "tagList": []
+          },
+          "metadata": {
+            "createdDate": "2021-12-29T10:08:33.423+00:00",
+            "createdByUserId": "713b5b3b-2bb1-53a5-ac62-238bbd2696bb",
+            "updatedDate": "2021-12-29T11:54:42.293+00:00",
+            "updatedByUserId": "713b5b3b-2bb1-53a5-ac62-238bbd2696bb"
+          }
+        }
+      ],
+      "instanceHrId": "in00000000023"
+    }
+  ]
+}

--- a/src/test/resources/processor/test_rules.json
+++ b/src/test/resources/processor/test_rules.json
@@ -115,7 +115,7 @@
   },
   {
     "field": "015",
-    "description": "Testing readDependingOnDataSource flag",
+    "description": "Testing item field mapping",
     "dataSources": [
       {
         "from": "$.holdings[0].items[*].barcode",
@@ -123,8 +123,7 @@
       },
       {
         "from": "$.holdings[0].hrid",
-        "subfield": "3",
-        "readDependingOnDataSource": 0
+        "subfield": "3"
       }
     ]
   },

--- a/src/test/resources/processor/test_rules.json
+++ b/src/test/resources/processor/test_rules.json
@@ -172,6 +172,24 @@
     ]
   },
   {
+    "field": "020",
+    "description": "Testing selection of array of simple fields (all nulls) into a control field",
+    "dataSources": [
+      {
+        "from": "$.holdings[0].items[*].volume",
+        "subfield": "a"
+      },
+      {
+        "from": "$.holdings[0].items[*].effectiveLocationId",
+        "subfield": "z"
+      },
+      {
+        "from": "$.holdings[0].hrid",
+        "subfield": "3"
+      }
+    ]
+  },
+  {
     "field": "00x",
     "description": "Nonexistent field just for the testing purposes",
     "dataSources": [

--- a/src/test/resources/processor/test_rules.json
+++ b/src/test/resources/processor/test_rules.json
@@ -173,7 +173,7 @@
   },
   {
     "field": "020",
-    "description": "Testing selection of array of simple fields (all nulls) into a control field",
+    "description": "Testing the field with empty volume in the item record",
     "dataSources": [
       {
         "from": "$.holdings[0].items[*].volume",


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/GMU-24

### PURPOSE

Fix issue with incorrect mapping when mapped item field is empty.

### APPROACH

**Problem explanation**

Each mapped item field(s) should be followed with a holding hrId subfield. 
The problem is that when all item fields for a particular mapped MARC field don't have a value in the item record then we should prevent automatic adding of an empty field with holding hrId subfield only. 
Therefore if we have the next mapping:
```
item barcode - 777__$a
item Enumeration - 777__$z
```
and both of them are empty we should exclude the related mapping rule for that field to not have a field with a holding hr id only - 777__$3ho00000001 -it's not correct, the field should be omitted.

For this purpose, the current business logic was relying on the index into automatically appended DataSource with described holding hrId subfield.(Rule consists from data sources, where each describes the subfield and path to JSON field)
The idea is that if we have appended holding hrId DataSource to the Rule then the Rule is related to the item fields and we should check if they are not null in order to know if we should map some not null fields with appended holding hr id subfield or we should omit the entire field.

The validation verifies the first item(0 index) in the DataSource list and if this filed has null value(empty item record field) then the entire field is omitted which is wrong. 
It is wrong because the Rule can have many DataSource's in it (one for each mapped item field) and we should not ommit the filed from mapping when only the first item field in a list is null because others can have value and we should put them to outcome MARC record field. 

**Solution**

Therefore validation logic was changed to check if DataSource's is related to item fields and we skip field only if all item fields aren't presented.
"

 