### PR TITLE
GMU-36: Jackson 2.14.0, log4j 2.19.0, commons-io 2.11.0, json-path 2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.14.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>${junit.version}</version>
@@ -44,7 +51,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.16.0</version>
+        <version>2.19.0</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -55,12 +62,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.12.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -75,7 +80,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.6</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -100,7 +105,7 @@
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
-      <version>2.4.0</version>
+      <version>2.7.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Upgrade Jackson from 2.12.0 to 2.14.0 fixing Denial of Service (DoS):
https://nvd.nist.gov/vuln/detail/CVE-2020-36518
https://nvd.nist.gov/vuln/detail/CVE-2022-42003
https://nvd.nist.gov/vuln/detail/CVE-2022-42004
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698

Upgrade log4j from 2.16.0 to 2.19.0 fixing Denial of Service (DoS) and Arbitrary Code Execution:
https://nvd.nist.gov/vuln/detail/CVE-2021-45105
https://nvd.nist.gov/vuln/detail/CVE-2021-44832

Upgrade commons-io from 2.6 to 2.11.0 fixing Directory Traversal:
https://nvd.nist.gov/vuln/detail/CVE-2021-29425

Upgrade json-path from 2.4.0 to 2.7.0. This indirectly upgrades json-smart from 2.3 to 2.4.7 fixing Denial of Service (DoS):
https://nvd.nist.gov/vuln/detail/CVE-2021-27568
https://nvd.nist.gov/vuln/detail/CVE-2021-31684