### PR TITLE
GMU-38: json-path 2.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@
       <artifactId>json-path</artifactId>
       <version>2.8.0</version>
     </dependency>
+    <dependency>
+      <groupId>net.minidev</groupId>
+      <artifactId>json-smart</artifactId>
+      <version>2.4.10</version>
+    </dependency>
 
     <dependency>
       <groupId>org.junit.platform</groupId>


### PR DESCRIPTION
Upgrade json-path from 2.7.0 to 2.8.0.

https://issues.folio.org/browse/GMU-38
For details see https://issues.folio.org/browse/MDEXP-596