### PR TITLE
GMU-39 - Electronic access indicator setter function should return empty value by default

### DIFF
--- a/src/main/java/org/folio/processor/translations/TranslationsFunctionHolder.java
+++ b/src/main/java/org/folio/processor/translations/TranslationsFunctionHolder.java
@@ -296,7 +296,7 @@ public enum TranslationsFunctionHolder implements TranslationFunction, Translati
           }
         }
       }
-      return StringUtils.SPACE;
+      return StringUtils.EMPTY;
     }
   },
 

--- a/src/test/java/org/folio/holder/TranslationFunctionHolderUnitTest.java
+++ b/src/test/java/org/folio/holder/TranslationFunctionHolderUnitTest.java
@@ -804,7 +804,7 @@ class TranslationFunctionHolderUnitTest {
     // when
     String result = translationFunction.apply(null, 0, null, null, metadata);
     // then
-    Assert.assertEquals(StringUtils.SPACE, result);
+    Assert.assertEquals(EMPTY, result);
   }
 
   @Test
@@ -816,7 +816,7 @@ class TranslationFunctionHolderUnitTest {
     // when
     String result = translationFunction.apply(null, 0, null, referenceData, metadata);
     // then
-    Assert.assertEquals(StringUtils.SPACE, result);
+    Assert.assertEquals(EMPTY, result);
   }
 
   @Test
@@ -832,7 +832,7 @@ class TranslationFunctionHolderUnitTest {
     // when
     String result = translationFunction.apply(null, 0, translation, referenceData, metadata);
     // then
-    Assert.assertEquals(StringUtils.SPACE, result);
+    Assert.assertEquals(EMPTY, result);
   }
 
   @Test


### PR DESCRIPTION
[GMU-39](https://issues.folio.org/browse/GMU-39) - Electronic access indicator setter function should return empty value by default

## Purpose
Electronic access indicator setter function should return empty value by default.

## Approach
* Changed default return value
* Updated unit tests

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [ ] Check logging
   - [x] There are no major code smells or security issues
