### PR TITLE
MDEXP-652 - "Linking ISSN" (022$l) and "Invalid ISBN" (020$z) missed for  MARC bib records generated on the fly

### DIFF
--- a/src/main/java/org/folio/processor/translations/TranslationsFunctionHolder.java
+++ b/src/main/java/org/folio/processor/translations/TranslationsFunctionHolder.java
@@ -65,6 +65,29 @@ public enum TranslationsFunctionHolder implements TranslationFunction, Translati
       return StringUtils.EMPTY;
     }
   },
+  APPEND_IDENTIFIER() {
+    @Override
+    public String apply(String identifierValue, int currentIndex, Translation translation, ReferenceDataWrapper referenceData, Metadata metadata) {
+      Object metadataIdentifierTypeIds = metadata.getData().get(IDENTIFIER_TYPE_METADATA).getData();
+      if (metadataIdentifierTypeIds != null) {
+        List<Map<String, String>> identifierTypes = (List<Map<String, String>>) metadataIdentifierTypeIds;
+        if (identifierTypes.size() > currentIndex && currentIndex == 0) {
+          String actualIdentifierTypeName = translation.getParameter(TYPE_PARAM);
+          for (JsonObjectWrapper wrapper : referenceData.get(IDENTIFIER_TYPES).values()) {
+            JSONObject referenceDataEntry = new JSONObject(wrapper == null ? Collections.emptyMap() : wrapper.getMap());
+            if (referenceDataEntry.getAsString(NAME).equalsIgnoreCase(actualIdentifierTypeName)) {
+              for (Map<String, String> identifierType : identifierTypes) {
+                if (identifierType.get(IDENTIFIER_TYPE_ID_PARAM).equalsIgnoreCase(referenceDataEntry.getAsString(ID_PARAM))) {
+                  return identifierType.get(VALUE_PARAM);
+                }
+              }
+            }
+          }
+        }
+      }
+      return StringUtils.EMPTY;
+    }
+  },
   SET_RELATED_IDENTIFIER() {
     @Override
     public String apply(String identifierValue, int currentIndex, Translation translation, ReferenceDataWrapper referenceData, Metadata metadata) {

--- a/src/test/java/org/folio/holder/TranslationFunctionHolderUnitTest.java
+++ b/src/test/java/org/folio/holder/TranslationFunctionHolderUnitTest.java
@@ -164,6 +164,46 @@ class TranslationFunctionHolderUnitTest {
   }
 
   @Test
+  void AppendIdentifier_shouldReturnInvalidIsbnValue() throws ParseException {
+    // given
+    String value = "isbn value";
+    TranslationFunction translationFunction = TranslationsFunctionHolder.APPEND_IDENTIFIER;
+
+    Translation translation = new Translation();
+    translation.setParameters(ImmutableMap.of("type", "Invalid ISBN"));
+
+    Metadata metadata = new Metadata();
+    metadata.addData("identifierType",
+      new Metadata.Entry("$.identifiers[*]",
+        asList(ImmutableMap.of("value", "isbn value", "identifierTypeId", "8261054f-be78-422d-bd51-4ed9f33c3422"),
+          ImmutableMap.of("value", "invalid isbn value", "identifierTypeId", "47c7bf8e-d2a3-4b3f-84b8-79944031a55a"))));
+    // when
+    String result = translationFunction.apply(value, 0, translation, referenceData, metadata);
+    // then
+    Assert.assertEquals("invalid isbn value", result);
+  }
+
+  @Test
+  void AppendIdentifier_shouldReturnEmptyValue_whenCurrentIndexIsGreaterThanZero() throws ParseException {
+    // given
+    String value = "isbn value";
+    TranslationFunction translationFunction = TranslationsFunctionHolder.APPEND_IDENTIFIER;
+
+    Translation translation = new Translation();
+    translation.setParameters(ImmutableMap.of("type", "Invalid ISBN"));
+
+    Metadata metadata = new Metadata();
+    metadata.addData("identifierType",
+      new Metadata.Entry("$.identifiers[*]",
+        asList(ImmutableMap.of("value", "isbn value", "identifierTypeId", "8261054f-be78-422d-bd51-4ed9f33c3422"),
+          ImmutableMap.of("value", "invalid isbn value", "identifierTypeId", "47c7bf8e-d2a3-4b3f-84b8-79944031a55a"))));
+    // when
+    String result = translationFunction.apply(value, 1, translation, referenceData, metadata);
+    // then
+    Assert.assertEquals(EMPTY, result);
+  }
+
+  @Test
   void SetRelatedIdentifier_shouldReturnEmptyValue_whenRelatedIdentifierDoesNotMatchCurrentIdentifierValue() throws ParseException {
     // given
     String value = "value";

--- a/src/test/java/org/folio/holder/TranslationFunctionHolderUnitTest.java
+++ b/src/test/java/org/folio/holder/TranslationFunctionHolderUnitTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -164,46 +165,6 @@ class TranslationFunctionHolderUnitTest {
   }
 
   @Test
-  void AppendIdentifier_shouldReturnInvalidIsbnValue() throws ParseException {
-    // given
-    String value = "isbn value";
-    TranslationFunction translationFunction = TranslationsFunctionHolder.APPEND_IDENTIFIER;
-
-    Translation translation = new Translation();
-    translation.setParameters(ImmutableMap.of("type", "Invalid ISBN"));
-
-    Metadata metadata = new Metadata();
-    metadata.addData("identifierType",
-      new Metadata.Entry("$.identifiers[*]",
-        asList(ImmutableMap.of("value", "isbn value", "identifierTypeId", "8261054f-be78-422d-bd51-4ed9f33c3422"),
-          ImmutableMap.of("value", "invalid isbn value", "identifierTypeId", "47c7bf8e-d2a3-4b3f-84b8-79944031a55a"))));
-    // when
-    String result = translationFunction.apply(value, 0, translation, referenceData, metadata);
-    // then
-    Assert.assertEquals("invalid isbn value", result);
-  }
-
-  @Test
-  void AppendIdentifier_shouldReturnEmptyValue_whenCurrentIndexIsGreaterThanZero() throws ParseException {
-    // given
-    String value = "isbn value";
-    TranslationFunction translationFunction = TranslationsFunctionHolder.APPEND_IDENTIFIER;
-
-    Translation translation = new Translation();
-    translation.setParameters(ImmutableMap.of("type", "Invalid ISBN"));
-
-    Metadata metadata = new Metadata();
-    metadata.addData("identifierType",
-      new Metadata.Entry("$.identifiers[*]",
-        asList(ImmutableMap.of("value", "isbn value", "identifierTypeId", "8261054f-be78-422d-bd51-4ed9f33c3422"),
-          ImmutableMap.of("value", "invalid isbn value", "identifierTypeId", "47c7bf8e-d2a3-4b3f-84b8-79944031a55a"))));
-    // when
-    String result = translationFunction.apply(value, 1, translation, referenceData, metadata);
-    // then
-    Assert.assertEquals(EMPTY, result);
-  }
-
-  @Test
   void SetRelatedIdentifier_shouldReturnEmptyValue_whenRelatedIdentifierDoesNotMatchCurrentIdentifierValue() throws ParseException {
     // given
     String value = "value";
@@ -266,6 +227,44 @@ class TranslationFunctionHolderUnitTest {
     String result = translationFunction.apply(value, 0, translation, referenceData, metadata);
     // then
     Assert.assertEquals("invalid isbn value", result);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "ISSN,0,issn value 0",
+    "Linking ISSN,0,linking issn value 0",
+    "Invalid ISSN,0,invalid issn value 0",
+    "ISSN,1,''",
+    "Linking ISSN,1,linking issn value 1",
+    "Invalid ISSN,1,invalid issn value 1",
+    "ISSN,2,''",
+    "Linking ISSN,2,''",
+    "Invalid ISSN,2,''",
+  })
+  void SetOrAppendIdentifier_ShouldReturnValueBasedOnOccurrenceNumber(String type, int currentIndex, String expectedValue) throws ParseException {
+    // given
+    var value = "any value";
+
+    TranslationFunction translationFunction = TranslationsFunctionHolder.SET_OR_APPEND_IDENTIFIER;
+
+    var translation = new Translation();
+    translation.setParameters(Collections.singletonMap("type", type));
+
+    var metadata = new Metadata();
+    metadata.addData("identifierType",
+      new Metadata.Entry("$.identifiers[*]",
+        asList(
+          ImmutableMap.of("value", "issn value 0", "identifierTypeId", "913300b2-03ed-469a-8179-c1092c991227"),
+          ImmutableMap.of("value", "linking issn value 0", "identifierTypeId", "5860f255-a27f-4916-a830-262aa900a6b9"),
+          ImmutableMap.of("value", "invalid issn value 0", "identifierTypeId", "846e7bb9-f06c-4ec9-8523-2527314fec9e"),
+          ImmutableMap.of("value", "invalid issn value 1", "identifierTypeId", "846e7bb9-f06c-4ec9-8523-2527314fec9e"),
+          ImmutableMap.of("value", "linking issn value 1", "identifierTypeId", "5860f255-a27f-4916-a830-262aa900a6b9"))));
+
+    // when
+    String result = translationFunction.apply(value, currentIndex, translation, referenceData, metadata);
+
+    // then
+    Assert.assertEquals(expectedValue, result);
   }
 
   @Test

--- a/src/test/resources/mockData/inventory/get_identifier_types_response.json
+++ b/src/test/resources/mockData/inventory/get_identifier_types_response.json
@@ -46,7 +46,7 @@
       "source": "folio"
     },
     {
-      "id": "c77e947d-ee93-4185-8c3e-06104bdda923",
+      "id": "5860f255-a27f-4916-a830-262aa900a6b9",
       "name": "Linking ISSN",
       "source": "folio"
     },


### PR DESCRIPTION
[MDEXP-652](https://issues.folio.org/browse/MDEXP-652) - "Linking ISSN" (022$l) and "Invalid ISBN" (020$z) missed for  MARC bib records generated on the fly

## Purpose
For the MARC bib records generated on the fly, the Instances identifiers  should be set the following way: "Linking ISSN" set to 022 \ \ $l and "Invalid ISBN" set to 020 \ \ $z 
UPD: also reproduced for :
"Invalid ISSN" 022 \ \ $z without  "ISSN"{}{}
"Cancelled GPO Item number" 074 \ \ $z without "GPO Item number" 074 \ \ $a
But these identifiers are missed in .mrc file in case Instance has no  ISSN (022$a) or  ISBN (020$a)
The issue is reproduced only for MARC bib records generated on the fly

## Approach
* Introduced new translation function
* Added unit tests

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [ ] Check logging
   - [x] There are no major code smells or security issues
