### PR TITLE
GMU-42: Switch Java and JDK from 11 to 17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildMvn {
   mvnDeploy = 'yes'
-  buildNode = 'jenkins-agent-java11'
+  buildNode = 'jenkins-agent-java17'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,9 @@
   </repositories>
 
   <properties>
+    <java.version>17</java.version>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <marc4j.version>2.9.1</marc4j.version>
     <junit.version>5.4.2</junit.version>
     <sonar.exclusions>**/Error.java</sonar.exclusions>
@@ -171,15 +174,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
-        <configuration>
-          <release>11</release>
-          <compilerArgument>-Xlint:unchecked</compilerArgument>
-        </configuration>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
FOLIO requires Java 17 and JDK 17 since Poppy: https://wiki.folio.org/display/TC/Poppy

Otherwise Sonar will fail:

```
[ERROR] The version of Java (11.0.20.1) used to run this analysis is deprecated, and SonarCloud no longer supports it. Please upgrade to Java 17 or later.
```

https://jenkins-aws.indexdata.com/blue/organizations/jenkins/folio-org%2Fgenerate-marc-utils/detail/GMU-41-json-path-2.9.0-guava-33.0.0/1/pipeline