### PR TITLE
MDEXP-816 - Holdings Permanent and Temporary location not being exported when Temporary location is set in holdings record

### DIFF
--- a/src/main/java/org/folio/processor/translations/TranslationsFunctionHolder.java
+++ b/src/main/java/org/folio/processor/translations/TranslationsFunctionHolder.java
@@ -415,6 +415,19 @@ public enum TranslationsFunctionHolder implements TranslationFunction, Translati
     }
   },
 
+  SET_HOLDINGS_TEMPORARY_LOCATION() {
+    @Override
+    public String apply(String locationId, int currentIndex, Translation translation, ReferenceDataWrapper referenceData, Metadata metadata) throws ParseException {
+      JSONObject entry = convertToJson(locationId, referenceData, LOCATIONS);
+      if (entry.isEmpty()) {
+        log.error("Location is not found by the given id: {}", locationId);
+        return StringUtils.EMPTY;
+      } else {
+        return entry.getAsString(NAME);
+      }
+    }
+  },
+
   SET_METADATA_DATE_TIME() {
     private final transient DateTimeFormatter targetFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd:hh-mm-ss");
     @Override

--- a/src/test/java/org/folio/holder/TranslationFunctionHolderUnitTest.java
+++ b/src/test/java/org/folio/holder/TranslationFunctionHolderUnitTest.java
@@ -1048,5 +1048,31 @@ class TranslationFunctionHolderUnitTest {
     assertEquals(EMPTY, result);
   }
 
+  @Test
+  void SetHoldingTemporaryLocation_shouldReturnLocationName() throws ParseException {
+    // given
+    TranslationFunction translationFunction = TranslationsFunctionHolder.SET_HOLDINGS_TEMPORARY_LOCATION;
+    Translation translation = new Translation();
+    String value = "d9cd0bed-1b49-4b5e-a7bd-064b8d177231";
+    Metadata metadata = new Metadata();
+    // when
+    String result = translationFunction.apply(value, 0, translation, referenceData, metadata);
+    // then
+    assertEquals("Miller General Stacks", result);
+  }
+
+  @Test
+  void SetHoldingTemporaryLocation_shouldReturnEmpty_whenLocationIdNotPresentInReferenceData() throws ParseException {
+    // given
+    TranslationFunction translationFunction = TranslationsFunctionHolder.SET_HOLDINGS_TEMPORARY_LOCATION;
+    Translation translation = new Translation();
+    String value = "bb0bc416-4112-11eb-b378-0242ac130002";
+    Metadata metadata = new Metadata();
+    // when
+    String result = translationFunction.apply(value, 0, translation, referenceData, metadata);
+    // then
+    assertEquals(EMPTY, result);
+  }
+
 
 }


### PR DESCRIPTION
[MDEXP-816](https://folio-org.atlassian.net/browse/MDEXP-816) - Holdings Permanent and Temporary location not being exported when Temporary location is set in holdings record

## Purpose
Introduce function to set temporary location.

## Approach
* Implemented new function
* Added unit tests

## Pre-Merge Checklist:
 Before merging this PR, please go through the following list and take appropriate actions.

 - Does this PR meet or exceed the expected quality standards?
   - [x] Code coverage on new code is 80% or greater
   - [x] Duplications on new code is 3% or less
   - [ ] Check logging
   - [x] There are no major code smells or security issues
